### PR TITLE
Impr - reverse display order for track days and maintenance list

### DIFF
--- a/rctabs/maintenance_tab.py
+++ b/rctabs/maintenance_tab.py
@@ -120,6 +120,16 @@ class MaintenancePage(ctk.CTkFrame):
       )
       self.maintenance_entries_container.pack(fill="both", expand=True, padx=20, pady=20)
       self.maintenance_stats_view_frame = ctk.CTkFrame(self, fg_color="transparent")
+      
+      def _on_mousewheel(event):
+        if event.num == 4 or event.delta > 0:
+            self.maintenance_entries_container._parent_canvas.yview_scroll(-1, "units")
+        elif event.num == 5 or event.delta < 0:
+            self.maintenance_entries_container._parent_canvas.yview_scroll(1, "units")
+
+      self.maintenance_entries_container._parent_canvas.bind_all("<MouseWheel>", _on_mousewheel)
+      self.maintenance_entries_container._parent_canvas.bind_all("<Button-4>", _on_mousewheel)
+      self.maintenance_entries_container._parent_canvas.bind_all("<Button-5>", _on_mousewheel)
 
    def _setup_statistics_view(self):
       self.stats_tabs = ctk.CTkTabview(self.maintenance_stats_view_frame)
@@ -205,10 +215,12 @@ class MaintenancePage(ctk.CTkFrame):
       for widget in self.maintenance_entries_container.winfo_children():
          widget.destroy()
       filtered_entries = self.maintenance_manager.filter_entries(
-         self.current_filter, 
+         self.current_filter,
          use_active_vehicle=not user_search
       )
-      for entry in filtered_entries:
+
+      reversed_maintenance_entries = list(reversed(filtered_entries))
+      for entry in reversed_maintenance_entries:
          self._create_maintenance_entry_card(entry)
       if self.maintenance_view_selector.get() == "Statistics":
          self.update_maintenance_statistics()

--- a/rctabs/track_sessions_tab.py
+++ b/rctabs/track_sessions_tab.py
@@ -51,7 +51,9 @@ class TrackSessionsPage(ctk.CTkFrame):
             new_session_button.pack(pady=10)
             return
 
-        for idx, track_day in enumerate(filtered_track_days):
+        # Reverse the order of track days to show the most recent first. New variable to not break original index.
+        reversed_track_day_list = list(reversed(filtered_track_days))
+        for idx, track_day in enumerate(reversed_track_day_list):
             card = ctk.CTkFrame(self.session_frame, corner_radius=10, border_width=1)
             card.pack(fill="x", pady=5, padx=10)
 
@@ -557,6 +559,7 @@ class TrackSessionsPage(ctk.CTkFrame):
             self.track_session_mngr.add_session(track_day_idx, new_session)
             self.session_form_window.destroy()
             self.display_track_days()
+            self.toggle_sessions_inline(track_day_idx, None)
             cleanup_mousewheel_bindings()
 
         cancel_button = ctk.CTkButton(


### PR DESCRIPTION
This commit changes the way the lists are displayed. Now the newest entry will be display at the top instead of the bottom. The list then becomes more of a timeline.

The commit also adds two smaller improvements as well for the above mentioned lists:
- The current session list view will remain open when a session is added to it.
- The maintenance list is now scrollable with the mouse wheel