### PR TITLE
Impr - Store data files under user local directory

### DIFF
--- a/rcfunc/data_utils.py
+++ b/rcfunc/data_utils.py
@@ -4,7 +4,7 @@ import json
 import os
 
 import os
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.join(os.path.expanduser("~"), ".local/racing-companion")
 data_file = os.path.join(BASE_DIR, ".rcstorage/track_sessions.json")
 vehicles_file = os.path.join(BASE_DIR, ".rcstorage/vehicles.json")
 maintenance_file = os.path.join(BASE_DIR, ".rcstorage/maintenance_entries.json")

--- a/readme.md
+++ b/readme.md
@@ -86,4 +86,4 @@ PYTHONPATH=. pytest
 
 ## Support
 ### Data Storage
-Currently stored in a plain **.json** file. It's simple to read and can be used by other tools. This will be updated in the future.
+The application uses `/home/$USER/racing-companion` as a storage directory, and data files will be stored under `/home/$USER/racing-companion/.rcstorage/`. Data files are currently stored in a plain **.json** file. It's simple to read and can be used by other tools. This will be updated in the future.


### PR DESCRIPTION
This commit changes the storage directory used for data files from the repo to $USER/.local rc storage directory. This is needed in order to not store data on installation path after the user have executed the soft linking script.