### PR TITLE
Impr - Add ruff linting to project

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -74,3 +74,37 @@ jobs:
             echo "FAIL - Racing-Companion did not start properly (exit code $code)."
             exit 1
           fi
+
+  ruff-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install dependencies
+        run: uv tool install ruff@latest
+
+      - name: Run ruff checks
+        run: |
+          set -e
+          echo "Running Ruff checks..."
+
+          EXIT_CODE=0
+
+          ruff check rctabs --preview || EXIT_CODE=$?
+          ruff check rcfunc --preview || EXIT_CODE=$?
+          ruff check tests  --preview || EXIT_CODE=$?
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "One or more Ruff checks failed."
+            exit $EXIT_CODE
+          else
+            echo "All Ruff checks passed."
+          fi

--- a/rcfunc/data_utils.py
+++ b/rcfunc/data_utils.py
@@ -3,7 +3,6 @@
 import json
 import os
 
-import os
 BASE_DIR = os.path.join(os.path.expanduser("~"), ".local/racing-companion")
 data_file = os.path.join(BASE_DIR, ".rcstorage/track_sessions.json")
 vehicles_file = os.path.join(BASE_DIR, ".rcstorage/vehicles.json")

--- a/rcfunc/maintenance_mngr.py
+++ b/rcfunc/maintenance_mngr.py
@@ -4,7 +4,6 @@
 # License: TBD
 
 from typing import List, Dict, Any, Optional, Tuple
-from datetime import datetime
 import re
 from dataclasses import dataclass, field
 from rcfunc.data_utils import save_maintenance_entries, load_maintenance_entries

--- a/rcfunc/track_session_mngr.py
+++ b/rcfunc/track_session_mngr.py
@@ -199,5 +199,7 @@ class TrackSessionMngr:
                   writer.writerow(row)
          return True
       except Exception as e:
-         # Optionally log the error
+         # Todo: Write a proper error log, displayed in the GUI somewhere.
+         print(f"Error exporting track day to CSV: {e}")
+
          return False

--- a/rctabs/maintenance_tab.py
+++ b/rctabs/maintenance_tab.py
@@ -1,9 +1,9 @@
 import customtkinter as ctk
-from tkinter import StringVar, messagebox
+from tkinter import messagebox
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 
 # Import the business logic layer
 from rcfunc.maintenance_mngr import MaintenanceMngr, MaintenanceEntry, MaintenanceFilter
@@ -196,10 +196,10 @@ class MaintenancePage(ctk.CTkFrame):
       self.refresh_maintenance_entries()
 
    def add_new_maintenance_entry(self):
-      dialog = MaintenanceEntryDialog(self.app, self.maintenance_manager, self._on_entry_saved)
+      MaintenanceEntryDialog(self.app, self.maintenance_manager, self._on_entry_saved)
 
    def edit_maintenance_entry(self, entry: MaintenanceEntry):
-      dialog = MaintenanceEntryDialog(self.app, self.maintenance_manager, self._on_entry_saved, entry)
+      MaintenanceEntryDialog(self.app, self.maintenance_manager, self._on_entry_saved, entry)
 
    def delete_maintenance_entry(self, entry: MaintenanceEntry):
       if messagebox.askyesno("Confirm Delete", f"Delete maintenance entry '{entry.title}'?"):
@@ -386,7 +386,9 @@ class MaintenanceEntryDialog:
       try:
          self.dialog.grab_set()
          self.dialog.focus_set()
-      except:
+      except Exception as e:
+         # Todo: Write a proper error log, displayed in the GUI somewhere.
+         print(f"Error setting dialog focus: {e}")
          pass
 
    def _setup_form(self):

--- a/rctabs/track_sessions_tab.py
+++ b/rctabs/track_sessions_tab.py
@@ -491,7 +491,7 @@ class TrackSessionsPage(ctk.CTkFrame):
                 text_color="#2C3E50"
             )
             vehicle_label.pack(fill="x", pady=(0, field_pady))
-            vehicle_value = track_day_vehicle
+
         else:
             ctk.CTkLabel(scrollable_frame, text="Vehicle:", anchor="w", font=("Arial", 12)).pack(fill="x", pady=(field_pady, 2))
             vehicle_var = StringVar(value=self.track_session_mngr.vehicles[0])
@@ -509,7 +509,6 @@ class TrackSessionsPage(ctk.CTkFrame):
                 text_color="#2C3E50"
             )
             vehicle_dropdown.pack(fill="x", pady=(0, field_pady))
-            vehicle_value = vehicle_var
 
         ctk.CTkLabel(scrollable_frame, text="Weather:", anchor="w", font=("Arial", 12)).pack(fill="x", pady=(field_pady, 2))
         weather_var = StringVar(value=self.track_session_mngr.weather_options[0])

--- a/readme.md
+++ b/readme.md
@@ -87,3 +87,8 @@ PYTHONPATH=. pytest
 ## Support
 ### Data Storage
 The application uses `/home/$USER/racing-companion` as a storage directory, and data files will be stored under `/home/$USER/racing-companion/.rcstorage/`. Data files are currently stored in a plain **.json** file. It's simple to read and can be used by other tools. This will be updated in the future.
+
+### Linting
+[ruff](https://github.com/astral-sh/ruff?tab=readme-ov-file) is used as linting tool. It can be installed and executed locally by using the support script in `tools/linting/lint_prj.sh` which wraps a `ruff --preview` call in the source directories for the project.
+
+Of course the `ruff` call can be executed freely as needed. The script is only for general help.

--- a/tests/maintenance_mngr_test.py
+++ b/tests/maintenance_mngr_test.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from rcfunc.maintenance_mngr import (
     MaintenanceMngr, MaintenanceEntry, MaintenanceFilter, MaintenanceStatistics
 )

--- a/tools/linting/lint_prj.sh
+++ b/tools/linting/lint_prj.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# This file is part of the Racing-Companion project.
+
+# Description: Support lint script for development using Ruff - https://github.com/astral-sh/ruff?tab=readme-ov-file
+
+# Variables for colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RCFUNC_DIR=$(realpath "$SCRIPT_DIR/../../rcfunc")
+RCTABS_DIR=$(realpath "$SCRIPT_DIR/../../rctabs")
+RCTEST_DIR=$(realpath "$SCRIPT_DIR/../../tests")
+
+
+log_info() {
+    { echo -e "${BLUE}[$(date +%H:%M:%S)] [INFO] - ${NC} $1"; }
+}
+log_error() {
+    { echo -e "${RED}[$(date +%H:%M:%S)] [ERROR] - ${NC} $1"; }
+}
+log_success() {
+      { echo -e "${GREEN}[$(date +%H:%M:%S)] [SUCCESS] - ${NC} $1"; }
+   }
+
+log_warning() {
+    { echo -e "${YELLOW}[$(date +%H:%M:%S)] [WARNING] - ${NC} $1"; }
+}
+
+# Print usage information with nice frame formatting
+usage() {
+      echo " "
+      echo -e "Usage: lint_prj.sh [options]"
+      echo -e "Options:"
+      echo -e "  --help, -h\t\tShow this help message"
+      echo -e "Description:"
+      echo -e "  This script lints the Racing Companion project using Ruff."
+      echo -e "  It checks the rcfunc, rctabs, and tests directories for linting issues."
+      echo " "
+}
+
+# Execution entry point
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+   usage
+   exit 0
+fi
+
+# Check if Ruff is installed
+if ! command -v ruff &> /dev/null; then
+    log_error "Unable to find 'ruff' in your PATH"
+    read -p "Do you want to install it using uv? [Y/n] " answer
+    answer=${answer:-Y}
+    if [[ "$answer" =~ ^[Yy]$ ]]; then
+       log_info "Installing ruff..."
+       if command -v uv &> /dev/null; then
+          log_info "uv is already installed. Proceeding with ruff installation..."
+       else
+          log_info "uv is not installed. Installing uv first..."
+          if curl -LsSf https://astral.sh/uv/install.sh | sh; then
+             log_success "uv installed successfully."
+          else
+             log_error "Failed to install uv. Unable to continue. Install uv manually and try again. Exiting..."
+             exit 1
+          fi
+       fi
+
+       uv tool install ruff@latest &> /dev/null
+       # Check if Ruff was installed successfully
+       if command -v ruff &> /dev/null; then
+          log_success "ruff installed successfully."
+       else
+          log_error "ruff installation failed. Unable to continue. Install ruff manually and try again. Exiting..."
+          exit 1
+       fi
+       log_success "ruff (uv) installation script completed successfully."
+    else
+       log_warning "Unable to continue without Ruff installed. Exiting..."
+       exit 1
+    fi
+    exit 1
+fi
+
+# lint the project files
+echo " "
+log_info "Linting functionality in $RCFUNC_DIR"
+ruff check "$RCFUNC_DIR" --preview
+
+echo " "
+log_info "Linting GUI tabs in $RCTABS_DIR"
+ruff check "$RCTABS_DIR" --preview
+
+echo " "
+log_info "Linting tests in $RCTEST_DIR"
+ruff check "$RCTEST_DIR" --preview
+
+log_success "Linting completed successfully. Some options may be solved automatically by running manually with 'ruff check --fix' in the respective directories."
+exit 0

--- a/tools/linting/readme.md
+++ b/tools/linting/readme.md
@@ -1,0 +1,27 @@
+# Linting
+
+`lint_prj.sh` wraps the [ruff](https://github.com/astral-sh/ruff?tab=readme-ov-file) linting for convenience.
+It will not automatically fix any issue instead just preview it. The script do not manipulate the output in any way.
+
+If the script is unable to find `ruff` in the user $PATH, it can be used to install it together with [uv](https://docs.astral.sh/uv/#highlights).
+
+## Source files
+The script will check following directories:
+
+* [rctabs](../../rctabs/)
+* [rcfunc](../../rcfunc/)
+* [tests](../../tests/)
+
+## Ruleset
+`ruff` default rules are used. No specific configuration is added.
+
+## Usage
+From repo root:
+```bash
+./tools/linting/lint_prj.sh
+```
+
+Help:
+```bash
+./tools/linting/lint_prj.sh -h
+```


### PR DESCRIPTION
This commit adds ruff linting to the project. It will lint the source files (rctabs, rcfunc and tests). The commit also adds the tool directory with a wrapper script around the ruff call which can be used to execute the linting locally. Usage instructions also provided to support the user.

A new job in github actions, commit workflow, is also added to run linting on commits pushed to the repo. This will hopefully improve code quality. Fixes to issues which was found also added.