### PR TITLE
Impr - Scrollbar for track day tab

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -28,7 +28,28 @@ jobs:
 
       - name: Test execution
         run: |
-          PYTHONPATH=. pytest
+          PYTHONPATH=. pytest --ignore=tests/gui_utils_test.py
+
+  GUI-unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          sudo ./install_dependencies.sh
+          pip3 install --upgrade Pillow customtkinter numpy matplotlib
+
+      - name: Run GUI unit tests
+        run: |
+          PYTHONPATH=. xvfb-run pytest tests/gui_utils_test.py
 
   User-Install-test:
     runs-on: ubuntu-latest

--- a/rcfunc/gui_utils.py
+++ b/rcfunc/gui_utils.py
@@ -1,0 +1,34 @@
+# This file is part of the Racing-Companion project.
+#
+# Description: GUI support functionality for the Racing Companion application tabs.
+# License: TBD
+
+def enable_mousewheel_scrolling(scrollable_frame):
+    """Enable mousewheel scrolling for a CTkScrollableFrame only when hovered."""
+
+    canvas = scrollable_frame._parent_canvas  # internal canvas
+
+    def _on_mousewheel(event):
+        print(f"Mouse wheel event detected: {event}")
+        if event.delta:  # Windows & MacOS
+            canvas.yview_scroll(int(-1 * (event.delta / 120)), "units")
+        elif event.num == 4:  # Linux scroll up
+            canvas.yview_scroll(-1, "units")
+        elif event.num == 5:  # Linux scroll down
+            canvas.yview_scroll(1, "units")
+
+    def _bind_mousewheel(event):
+        print(f"Binding mouse wheel events to {scrollable_frame}")
+        canvas.bind_all("<MouseWheel>", _on_mousewheel)
+        canvas.bind_all("<Button-4>", _on_mousewheel)
+        canvas.bind_all("<Button-5>", _on_mousewheel)
+
+    def _unbind_mousewheel(event):
+        print(f"Unbinding mouse wheel events from {scrollable_frame}")
+        canvas.unbind_all("<MouseWheel>")
+        canvas.unbind_all("<Button-4>")
+        canvas.unbind_all("<Button-5>")
+
+    # Bind when mouse enters the scrollable frame, unbind when it leaves
+    scrollable_frame.bind("<Enter>", _bind_mousewheel)
+    scrollable_frame.bind("<Leave>", _unbind_mousewheel)

--- a/rctabs/maintenance_tab.py
+++ b/rctabs/maintenance_tab.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, Optional
 
 # Import the business logic layer
 from rcfunc.maintenance_mngr import MaintenanceMngr, MaintenanceEntry, MaintenanceFilter
+import rcfunc.gui_utils as gui_utils
 
 class MaintenancePage(ctk.CTkFrame):
    """GUI layer for maintenance management"""
@@ -119,17 +120,8 @@ class MaintenancePage(ctk.CTkFrame):
          fg_color="transparent"
       )
       self.maintenance_entries_container.pack(fill="both", expand=True, padx=20, pady=20)
+      gui_utils.enable_mousewheel_scrolling(self.maintenance_entries_container)
       self.maintenance_stats_view_frame = ctk.CTkFrame(self, fg_color="transparent")
-      
-      def _on_mousewheel(event):
-        if event.num == 4 or event.delta > 0:
-            self.maintenance_entries_container._parent_canvas.yview_scroll(-1, "units")
-        elif event.num == 5 or event.delta < 0:
-            self.maintenance_entries_container._parent_canvas.yview_scroll(1, "units")
-
-      self.maintenance_entries_container._parent_canvas.bind_all("<MouseWheel>", _on_mousewheel)
-      self.maintenance_entries_container._parent_canvas.bind_all("<Button-4>", _on_mousewheel)
-      self.maintenance_entries_container._parent_canvas.bind_all("<Button-5>", _on_mousewheel)
 
    def _setup_statistics_view(self):
       self.stats_tabs = ctk.CTkTabview(self.maintenance_stats_view_frame)

--- a/rctabs/track_sessions_tab.py
+++ b/rctabs/track_sessions_tab.py
@@ -1,6 +1,8 @@
 import os
 import customtkinter as ctk
 import tkinter.filedialog as fd
+import rcfunc.gui_utils as gui_utils
+
 from tkinter import StringVar
 from tkinter import messagebox
 from rcfunc.data_utils import save_data
@@ -25,8 +27,9 @@ class TrackSessionsPage(ctk.CTkFrame):
 
     def setup_track_sessions_page(self):
         """Track session logging with card-style design."""
-        self.session_frame = ctk.CTkFrame(self)
+        self.session_frame = ctk.CTkScrollableFrame(self)
         self.session_frame.pack(fill="both", expand=True, padx=10, pady=10)
+        gui_utils.enable_mousewheel_scrolling(self.session_frame)
         self.display_track_days()
 
     def display_track_days(self):

--- a/tests/gui_utils_test.py
+++ b/tests/gui_utils_test.py
@@ -1,0 +1,42 @@
+# This file is part of the Racing-Companion project.
+#
+# Description: Unit test for GUI utils functionality for the Racing Companion application.
+# License: TBD
+
+import pytest
+import customtkinter as ctk
+
+from rcfunc.gui_utils import enable_mousewheel_scrolling
+
+@pytest.fixture(scope="module")
+def tk_root():
+    root = ctk.CTk()
+    yield root
+    root.destroy()
+
+def test_enable_mousewheel_scrolling_binds_and_unbinds(tk_root):
+    # Create a scrollable frame
+    frame = ctk.CTkScrollableFrame(tk_root, width=200, height=200)
+    frame.pack()
+
+    # Enable scrolling
+    enable_mousewheel_scrolling(frame)
+
+    canvas = frame._parent_canvas
+
+    # Initially there should be no bindings
+    assert not canvas.bind("<MouseWheel>")
+
+    # Simulate mouse entering the frame
+    frame.event_generate("<Enter>")
+    tk_root.update_idletasks()
+
+    # Now the binding should exist
+    assert canvas.bind_all("<MouseWheel>") is not None
+
+    # Simulate mouse leaving the frame
+    frame.event_generate("<Leave>")
+    tk_root.update_idletasks()
+
+    # Binding should be gone
+    assert not canvas.bind_all("<MouseWheel>")


### PR DESCRIPTION
This commit adds the scrolling functionality to the track day list tab, needed due to not full list is visible when the entry amount is more then the start size of the app. In order to be able to test the mousewheel binding, small refactoring is done also from the maintenance tab in order to have common code. Scrolling functionality is seperated out in a new utility file for the GUI.

The commit also include a unit test for the binding.